### PR TITLE
slight tweaks to header and "see more" underlines

### DIFF
--- a/_includes/article-cards.scss
+++ b/_includes/article-cards.scss
@@ -317,6 +317,8 @@ article.big {
     }
     &:hover {
       text-decoration: underline;
+      text-decoration-thickness: 3px;
+      text-underline-offset: 3px;
     }
   }
   @media (max-width: 280px) {

--- a/_includes/header.scss
+++ b/_includes/header.scss
@@ -42,18 +42,20 @@ nav {
       content: "";
       position: absolute;
       bottom: -1px;
-      width: 0;
+      width: 100%;
       height: 3px;
       margin: 5px 0 0;
-      transition: width 0.2s, opacity 0.2s;
+      transition: all 0.2s;
       background: white;
       border-radius: 1.5px;
       opacity: 0;
       left: 0;
+      transform-origin: center;
+      transform: scale(0);
     }
     &:hover {
       &:after {
-        width: 100%;
+        transform: scale(1);
         opacity: 1;
       }
     }


### PR DESCRIPTION
header link underlines now expand from center instead of the left, and "see more" underlines are thicker and offset more from the link element