### PR TITLE
miniscule header underline animation tweak

### DIFF
--- a/_includes/header.scss
+++ b/_includes/header.scss
@@ -51,11 +51,11 @@ nav {
       opacity: 0;
       left: 0;
       transform-origin: center;
-      transform: scale(0);
+      transform: scaleX(0);
     }
     &:hover {
       &:after {
-        transform: scale(1);
+        transform: scaleX(1);
         opacity: 1;
       }
     }


### PR DESCRIPTION
Instead of expanding in both directions, underlines now only expand in the X direction. This gives it a more underline-y feel